### PR TITLE
Fix for Flutter 1.19

### DIFF
--- a/lib/src/custom_widget.dart
+++ b/lib/src/custom_widget.dart
@@ -129,15 +129,20 @@ class CustomThumbShape extends SliderComponentShape {
   }
 
   @override
-  void paint(PaintingContext context, Offset center,
-      {Animation<double> activationAnimation,
-      Animation<double> enableAnimation,
-      bool isDiscrete,
-      TextPainter labelPainter,
-      RenderBox parentBox,
-      SliderThemeData sliderTheme,
-      TextDirection textDirection,
-      double value}) {
+  void paint(
+    PaintingContext context,
+    Offset center, {
+    Animation<double> activationAnimation,
+    Animation<double> enableAnimation,
+    bool isDiscrete,
+    TextPainter labelPainter,
+    RenderBox parentBox,
+    SliderThemeData sliderTheme,
+    TextDirection textDirection,
+    double value,
+    double textScaleFactor,
+    Size sizeWithOverflow,
+  }) {
     final Canvas canvas = context.canvas;
 
     final Paint paint = Paint()


### PR DESCRIPTION
Fix for Flutter 1.19.
Exception: Error: The method 'CustomThumbShape.paint' has fewer named arguments than those of overridden method 'SliderComponentShape.paint'.